### PR TITLE
Include more extensions for syntax highlighting.

### DIFF
--- a/foxpro/package.json
+++ b/foxpro/package.json
@@ -14,7 +14,18 @@
 		"languages": [{
 			"id": "foxpro",
 			"aliases": ["foxpro", "Visual FoxPro", "VFP"],
-			"extensions": [".prg", ".PRG"],
+			"extensions": [
+				".prg",
+				".PRG",
+				".sc2",
+				".SC2",
+				".vc2",
+				".VC2",
+				".mn2",
+				".MN2",
+				".pj2",
+				".PJ2"
+			],
 			"configuration": "./foxpro.configuration.json"
 		}],
 		"grammars": [{

--- a/foxpro/syntaxes/foxpro.plist
+++ b/foxpro/syntaxes/foxpro.plist
@@ -7,6 +7,10 @@
 	<key>fileTypes</key>
 	<array>
 		<string>prg</string>
+		<string>sc2</string>
+		<string>vc2</string>
+		<string>mn2</string>
+		<string>pj2</string>
 	</array>
 	<key>keyEquivalent</key>
 	<string>^~A</string>

--- a/foxpro/syntaxes/foxpro.tmLanguage
+++ b/foxpro/syntaxes/foxpro.tmLanguage
@@ -5,6 +5,10 @@
   <key>fileTypes</key>
 	<array>
 		<string>prg</string>
+		<string>sc2</string>
+		<string>vc2</string>
+		<string>mn2</string>
+		<string>pj2</string>
 	</array>
 	<key>name</key>
 	<string>FoxPro</string>


### PR DESCRIPTION
Add '.sc2', '.mn2', and '.pj2'.

These are the extensions that [foxbin2prg](https://github.com/fdbozzo/foxbin2prg) uses when making the FoxPro binary forms, menus, and project file compatible with source control.  They are round-trip capable text files.